### PR TITLE
fix: README, `--generate-name` is missing

### DIFF
--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -8,7 +8,7 @@ Assumes you are using Helm V3:
 
 ```bash
 $ helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
-$ helm install external-secrets/kubernetes-external-secrets --skip-crds
+$ helm install external-secrets/kubernetes-external-secrets --skip-crds --generate-name
 ```
 
 See below for [Helm V2 considerations](#helm-v2-considerations) when installing the chart.


### PR DESCRIPTION
While trying this awesome project, I found the example command which does not work.

```
$ helm install external-secrets/kubernetes-external-secrets --skip-crds
Error: must either provide a name or specify --generate-name
```